### PR TITLE
Remove Field.initMortals

### DIFF
--- a/src/arpx/field/Field.hx
+++ b/src/arpx/field/Field.hx
@@ -64,10 +64,6 @@ class Field implements IArpObject implements ITickable implements IInteractable 
 		return anchorField.add(anchor);
 	}
 
-	public function reinitMortals():Void {
-		OmapOp.copy(this.initMortals, this.mortals);
-	}
-
 	public function tick(timeslice:Float):Bool {
 		for (mortal in this.mortals) mortal.tickChild(timeslice, this);
 		for (anchor in this.anchors) anchor.refresh(this);

--- a/src/arpx/field/Field.hx
+++ b/src/arpx/field/Field.hx
@@ -36,7 +36,6 @@ class Field implements IArpObject implements ITickable implements IInteractable 
 	@:arpHeatUp private function heatUp():Bool {
 		if (this.hitField == null) this.hitField = new HitObjectField<HitGeneric, HitMortal>(new HitWithCuboid());
 		if (this.anchorField == null) this.anchorField = new HitField<HitGeneric, Anchor>(new HitWithCuboid());
-		this.reinitMortals();
 		return true;
 	}
 

--- a/src/arpx/field/Field.hx
+++ b/src/arpx/field/Field.hx
@@ -1,7 +1,6 @@
 package arpx.field;
 
 import arp.domain.IArpObject;
-import arp.ds.impl.StdOmap;
 import arp.ds.IOmap;
 import arp.ds.lambda.OmapOp;
 import arp.hit.fields.HitField;
@@ -20,11 +19,9 @@ import arpx.reactFrame.ReactFrame;
 @:arpType("field")
 class Field implements IArpObject implements ITickable implements IInteractable implements IFieldImpl {
 
-	@:arpBarrier @:arpField(true) public var initMortals:IOmap<String, Mortal>;
-	@:arpBarrier @:arpField(false) private var _mortals:IOmap<String, Mortal>;
+	@:arpBarrier @:arpDeepCopy @:arpField(true) public var mortals:IOmap<String, Mortal>;
 	@:arpBarrier @:arpField public var anchors:IOmap<String, Anchor>;
 
-	public var mortals(default, null):IOmap<String, Mortal>;
 	public var gridSize(get, never):Int;
 	public var width(get, never):Int;
 	public var height(get, never):Int;
@@ -37,7 +34,6 @@ class Field implements IArpObject implements ITickable implements IInteractable 
 	public function new() return;
 
 	@:arpHeatUp private function heatUp():Bool {
-		if (this.mortals == null) this.mortals = @:privateAccess new StdOmap<String, Mortal>();
 		if (this.hitField == null) this.hitField = new HitObjectField<HitGeneric, HitMortal>(new HitWithCuboid());
 		if (this.anchorField == null) this.anchorField = new HitField<HitGeneric, Anchor>(new HitWithCuboid());
 		this.reinitMortals();

--- a/src/arpx/mortal/Mortal.hx
+++ b/src/arpx/mortal/Mortal.hx
@@ -19,7 +19,7 @@ import arpx.structs.ArpPosition;
 @:arpType("mortal", "null")
 class Mortal implements IArpObject implements ITickableChild<Field> implements IMortalImpl {
 
-	@:arpBarrier @:arpField public var driver:Driver;
+	@:arpBarrier @:arpDeepCopy @:arpField public var driver:Driver;
 	@:arpField public var position:ArpPosition;
 	@:arpField public var visible:Bool = true;
 	@:arpField public var params:ArpParams;

--- a/src/arpx/mortal/Mortal.hx
+++ b/src/arpx/mortal/Mortal.hx
@@ -25,8 +25,6 @@ class Mortal implements IArpObject implements ITickableChild<Field> implements I
 	@:arpField public var params:ArpParams;
 	@:arpBarrier @:arpField(true) public var hitFrames:ISet<HitFrame>;
 
-	@:arpField private var field:Field;
-
 	private var hitMortals:Map<String, HitMortal>;
 	private var reactRecord:ISet<String>;
 	private var lastReactRecord:ISet<String>;


### PR DESCRIPTION
Close #47 

Just `Field.arpClone()` and now we can have clone mortals, thanks to `@:arpDeepCopy`