### PR TITLE
Reimplement MotionDriver as cold API

### DIFF
--- a/src/arpx/mortal/ChipMortal.hx
+++ b/src/arpx/mortal/ChipMortal.hx
@@ -13,6 +13,8 @@ class ChipMortal extends Mortal {
 	public function new() super();
 
 	override public function startAction(actionName:String, restart:Bool = false):Bool {
+		if (this.driver != null) return this.driver.startAction(this, actionName, restart);
+
 		this.params.set("face", actionName);
 		return true;
 	}

--- a/src/arpx/motion/Motion.hx
+++ b/src/arpx/motion/Motion.hx
@@ -10,12 +10,12 @@ import arpx.reactFrame.ReactFrame;
 @:arpType("motion", "motion")
 class Motion implements IArpObject {
 
-	@:arpBarrier @:arpField(true) public var motions:IMap<String, Motion>;
+	@:arpField(true) public var motions:IMap<String, Motion>;
 	@:arpField public var time:Float;
-	@:arpBarrier @:arpField(true) public var nextMotions:IList<NextMotion>;
+	@:arpField(true) public var nextMotions:IList<NextMotion>;
 	@:arpField public var loopAction:String;
-	@:arpBarrier @:arpField(true) public var motionFrames:IList<MotionFrame>;
-	@:arpBarrier @:arpField(true) public var reactFrames:IList<ReactFrame>;
+	@:arpField(true) public var motionFrames:IList<MotionFrame>;
+	@:arpField(true) public var reactFrames:IList<ReactFrame>;
 
 	public function new() {
 	}

--- a/src/arpx/motionFrame/MotionFrame.hx
+++ b/src/arpx/motionFrame/MotionFrame.hx
@@ -12,7 +12,7 @@ import arpx.structs.ArpPosition;
 class MotionFrame implements IArpObject {
 
 	@:arpField public var params:ArpParams;
-	@:arpBarrier @:arpField(true) public var hitFrames:ISet<HitFrame>;
+	@:arpField(true) public var hitFrames:ISet<HitFrame>;
 	@:arpField public var time:Float;
 	@:arpField public var dX:Float;
 	@:arpField public var dY:Float;

--- a/src/arpx/motionSet/MotionSet.hx
+++ b/src/arpx/motionSet/MotionSet.hx
@@ -9,9 +9,9 @@ import arpx.nextMotion.NextMotion;
 @:arpType("motionSet", "motionSet")
 class MotionSet implements IArpObject {
 
-	@:arpBarrier @:arpField(true) public var motions:IMap<String, Motion>;
-	@:arpBarrier @:arpField(true) public var nextMotions:IList<NextMotion>;
-	@:arpBarrier @:arpField public var initMotion:Motion;
+	@:arpField(true) public var motions:IMap<String, Motion>;
+	@:arpField(true) public var nextMotions:IList<NextMotion>;
+	@:arpField public var initMotion:Motion;
 
 	public function new() {
 	}


### PR DESCRIPTION
`Driver` APIs no longer require heatup.

Generally speaking, heating up "Assets" are good, but heating up "Entities" leads to heatup waiting hell, and `Driver`s are something that belongs to "Entities", along with `Mortal`s.