### PR TITLE
Further convenience methods handling Mortals and Drivers

### DIFF
--- a/src/arpx/driver/Driver.hx
+++ b/src/arpx/driver/Driver.hx
@@ -9,6 +9,9 @@ class Driver implements IArpObject {
 
 	@:arpField public var dHitType:String;
 
+	public var time(get, never):Float;
+	private function get_time():Float return 0;
+
 	public function new() return;
 
 	public function tick(field:Field, mortal:Mortal):Void return;

--- a/src/arpx/driver/Driver.hx
+++ b/src/arpx/driver/Driver.hx
@@ -13,7 +13,7 @@ class Driver implements IArpObject {
 
 	public function tick(field:Field, mortal:Mortal):Void return;
 
-	public function towardD(mortal:Mortal, period:Float, x:Float = 0, y:Float = 0, z:Float = 0):Bool return false;
+	public function towardD(mortal:Mortal, time:Float, x:Float = 0, y:Float = 0, z:Float = 0):Bool return false;
 
 	public function startAction(mortal:Mortal, actionName:String, restart:Bool = false):Bool return false;
 }

--- a/src/arpx/driver/Driver.hx
+++ b/src/arpx/driver/Driver.hx
@@ -8,9 +8,7 @@ import arpx.mortal.Mortal;
 class Driver implements IArpObject {
 
 	@:arpField public var dHitType:String;
-
-	public var time(get, never):Float;
-	private function get_time():Float return 0;
+	@:arpField public var time:Float;
 
 	public function new() return;
 

--- a/src/arpx/driver/LinearDriver.hx
+++ b/src/arpx/driver/LinearDriver.hx
@@ -10,8 +10,6 @@ class LinearDriver extends Driver {
 	@:arpField public var dPos:ArpPosition;
 	@:arpField public var hasDir:Bool;
 	@:arpField public var nowTime:Float = 0;
-	@:arpField("time") private var _time:Float = 0;
-	override public function get_time():Float return this._time;
 
 	public function new() super();
 
@@ -23,7 +21,7 @@ class LinearDriver extends Driver {
 			this.dPos.dir.valueRadian = Math.atan2(y, x);
 			this.hasDir = true;
 		}
-		this._time = time;
+		this.time = time;
 		this.nowTime = 0;
 		return true;
 	}
@@ -48,7 +46,7 @@ class LinearDriver extends Driver {
 			dx *= dTime;
 			dy *= dTime;
 			dz *= dTime;
-			this.nowTime = this._time = 0;
+			this.nowTime = this.time = 0;
 		} else {
 			this.nowTime++;
 		}

--- a/src/arpx/driver/LinearDriver.hx
+++ b/src/arpx/driver/LinearDriver.hx
@@ -9,12 +9,12 @@ class LinearDriver extends Driver {
 
 	@:arpField public var dPos:ArpPosition;
 	@:arpField public var hasDir:Bool;
-	@:arpField public var time:Float;
-	@:arpField public var period:Float;
+	@:arpField public var nowTime:Float = 0;
+	@:arpField public var time:Float = 0;
 
 	public function new() super();
 
-	override public function towardD(mortal:Mortal, period:Float, x:Float = 0, y:Float = 0, z:Float = 0):Bool {
+	override public function towardD(mortal:Mortal, time:Float, x:Float = 0, y:Float = 0, z:Float = 0):Bool {
 		this.dPos.x = x;
 		this.dPos.y = y;
 		this.dPos.z = z;
@@ -22,13 +22,13 @@ class LinearDriver extends Driver {
 			this.dPos.dir.valueRadian = Math.atan2(y, x);
 			this.hasDir = true;
 		}
-		this.period = period;
-		this.time = 0;
+		this.time = time;
+		this.nowTime = 0;
 		return true;
 	}
 
 	override public function tick(field:Field, mortal:Mortal):Void {
-		if (this.period <= 0) {
+		if (this.time <= 0) {
 			mortal.stayWithHit(field, this.dHitType);
 			return;
 		}
@@ -38,18 +38,18 @@ class LinearDriver extends Driver {
 			pos.dir.value = this.dPos.dir.value;
 			mortal.params.set("dir", pos.dir);
 		}
-		var dx = this.dPos.x / period;
-		var dy = this.dPos.y / period;
-		var dz = this.dPos.z / period;
+		var dx = this.dPos.x / time;
+		var dy = this.dPos.y / time;
+		var dz = this.dPos.z / time;
 
-		var dTime = this.period - this.time;
+		var dTime = this.time - this.nowTime;
 		if (dTime < 1) {
 			dx *= dTime;
 			dy *= dTime;
 			dz *= dTime;
-			this.time = this.period;
+			this.nowTime = this.time = 0;
 		} else {
-			this.time++;
+			this.nowTime++;
 		}
 		mortal.moveDWithHit(field, dx, dy, dz, this.dHitType);
 	}

--- a/src/arpx/driver/LinearDriver.hx
+++ b/src/arpx/driver/LinearDriver.hx
@@ -10,7 +10,8 @@ class LinearDriver extends Driver {
 	@:arpField public var dPos:ArpPosition;
 	@:arpField public var hasDir:Bool;
 	@:arpField public var nowTime:Float = 0;
-	@:arpField public var time:Float = 0;
+	@:arpField("time") private var _time:Float = 0;
+	override public function get_time():Float return this._time;
 
 	public function new() super();
 
@@ -22,7 +23,7 @@ class LinearDriver extends Driver {
 			this.dPos.dir.valueRadian = Math.atan2(y, x);
 			this.hasDir = true;
 		}
-		this.time = time;
+		this._time = time;
 		this.nowTime = 0;
 		return true;
 	}
@@ -47,7 +48,7 @@ class LinearDriver extends Driver {
 			dx *= dTime;
 			dy *= dTime;
 			dz *= dTime;
-			this.nowTime = this.time = 0;
+			this.nowTime = this._time = 0;
 		} else {
 			this.nowTime++;
 		}

--- a/src/arpx/driver/decorators/CompositeDriver.hx
+++ b/src/arpx/driver/decorators/CompositeDriver.hx
@@ -11,9 +11,9 @@ class CompositeDriver extends Driver {
 
 	public function new() super();
 
-	override public function towardD(mortal:Mortal, period:Float, x:Float = 0, y:Float = 0, z:Float = 0):Bool {
+	override public function towardD(mortal:Mortal, time:Float, x:Float = 0, y:Float = 0, z:Float = 0):Bool {
 		for (driver in this.drivers) {
-			if (driver.towardD(mortal, period, x, y, z)) return true;
+			if (driver.towardD(mortal, time, x, y, z)) return true;
 		}
 		return false;
 	}

--- a/src/arpx/driver/decorators/CompositeDriver.hx
+++ b/src/arpx/driver/decorators/CompositeDriver.hx
@@ -9,6 +9,15 @@ class CompositeDriver extends Driver {
 
 	@:arpBarrier @:arpDeepCopy @:arpField(true) public var drivers:IList<Driver>;
 
+	override public function get_time():Float {
+		var t:Float = 0;
+		for (driver in this.drivers) {
+			t = driver.time;
+			if (t != 0) break;
+		}
+		return t;
+	}
+
 	public function new() super();
 
 	override public function towardD(mortal:Mortal, time:Float, x:Float = 0, y:Float = 0, z:Float = 0):Bool {

--- a/src/arpx/mortal/Mortal.hx
+++ b/src/arpx/mortal/Mortal.hx
@@ -61,15 +61,15 @@ class Mortal implements IArpObject implements ITickableChild<Field> implements I
 		return true;
 	}
 
-	public function toward(period:Float, x:Float, y:Float, z:Float = 0, gridSize:Float = 1.0):Bool {
+	public function toward(time:Float, x:Float, y:Float, z:Float = 0, gridSize:Float = 1.0):Bool {
 		if (this.driver == null) return false;
 		var position:ArpPosition = this.position;
-		return this.driver.towardD(this, period, x * gridSize - position.x, y * gridSize - position.y, z * gridSize - position.z);
+		return this.driver.towardD(this, time, x * gridSize - position.x, y * gridSize - position.y, z * gridSize - position.z);
 	}
 
-	public function towardD(period:Float, x:Float = 0, y:Float = 0, z:Float = 0, gridSize:Float = 1.0):Bool {
+	public function towardD(time:Float, x:Float = 0, y:Float = 0, z:Float = 0, gridSize:Float = 1.0):Bool {
 		if (this.driver == null) return false;
-		return this.driver.towardD(this, period, x * gridSize, y * gridSize, z * gridSize);
+		return this.driver.towardD(this, time, x * gridSize, y * gridSize, z * gridSize);
 	}
 
 	public function startAction(actionName:String, restart:Bool = false):Bool {

--- a/src/arpx/mortal/Mortal.hx
+++ b/src/arpx/mortal/Mortal.hx
@@ -61,6 +61,12 @@ class Mortal implements IArpObject implements ITickableChild<Field> implements I
 		return true;
 	}
 
+	public var driverTime(get, never):Float;
+	public function get_driverTime():Float {
+		if (this.driver == null) return 0;
+		return this.driver.time;
+	}
+
 	public function toward(time:Float, x:Float, y:Float, z:Float = 0, gridSize:Float = 1.0):Bool {
 		if (this.driver == null) return false;
 		var position:ArpPosition = this.position;

--- a/tests/arpx/driver/LinearDriverCase.hx
+++ b/tests/arpx/driver/LinearDriverCase.hx
@@ -35,7 +35,7 @@ class LinearDriverCase {
 		assertMatch(0, me.dPos.x);
 		assertMatch(0, me.dPos.y);
 		assertMatch(0, me.dPos.z);
-		assertMatch(0, me.period);
+		assertMatch(0, me.time);
 		assertMatch(0, pos.dir.value);
 		mortal.toward(2, 2, 4, 6);
 		assertMatch(1, pos.x);
@@ -44,7 +44,7 @@ class LinearDriverCase {
 		assertMatch(1, me.dPos.x);
 		assertMatch(2, me.dPos.y);
 		assertMatch(3, me.dPos.z);
-		assertMatch(2, me.period);
+		assertMatch(2, me.time);
 		//assertTrue(0 != pos.dir.value);
 		mortal.toward(2, 1, 2, 3, 3);
 		assertMatch(1, pos.x);
@@ -53,7 +53,7 @@ class LinearDriverCase {
 		assertMatch(2, me.dPos.x);
 		assertMatch(4, me.dPos.y);
 		assertMatch(6, me.dPos.z);
-		assertMatch(2, me.period);
+		assertMatch(2, me.time);
 		//assertTrue(0 != pos.dir.value);
 		mortal.towardD(1, 1, 1, 1);
 		assertMatch(1, pos.x);
@@ -62,7 +62,7 @@ class LinearDriverCase {
 		assertMatch(1, me.dPos.x);
 		assertMatch(1, me.dPos.y);
 		assertMatch(1, me.dPos.z);
-		assertMatch(1, me.period);
+		assertMatch(1, me.time);
 		//assertTrue(0 != pos.dir.value);
 		mortal.towardD(3, 1, 0, 1, 3);
 		assertMatch(1, pos.x);
@@ -71,7 +71,7 @@ class LinearDriverCase {
 		assertMatch(3, me.dPos.x);
 		assertMatch(0, me.dPos.y);
 		assertMatch(3, me.dPos.z);
-		assertMatch(3, me.period);
+		assertMatch(3, me.time);
 		//assertMatch(0, pos.dir.value);
 	}
 


### PR DESCRIPTION
Q. Why doesn't `Driver.time` goes into `Mortal.time`?
A. Because we don't need it for some mortals.

Q. Should `MotionDriver`s better have its own arpType? (how about naming it `Animator` btw)
A. Thinking...