### PR TITLE
More useful Menus

### DIFF
--- a/src/arpx/hud/ChipMenuHud.hx
+++ b/src/arpx/hud/ChipMenuHud.hx
@@ -14,6 +14,7 @@ class ChipMenuHud extends Hud implements IMenuAxes {
 	@:arpField public var dPosition:ArpPosition;
 	@:arpField public var axis:String = "y";
 	@:arpField public var execute:String = "s";
+	@:arpField public var abort:String = null;
 	@:arpBarrier @:arpField public var menu:Menu;
 
 	@:arpImpl private var arpImpl:ChipMenuHudImpl;

--- a/src/arpx/hud/ChipMenuHud.hx
+++ b/src/arpx/hud/ChipMenuHud.hx
@@ -3,12 +3,12 @@ package arpx.hud;
 import arpx.chip.Chip;
 import arpx.impl.cross.hud.ChipMenuHudImpl;
 import arpx.input.Input;
-import arpx.inputAxis.InputAxis;
+import arpx.menu.IMenuAxes;
 import arpx.menu.Menu;
 import arpx.structs.ArpPosition;
 
 @:arpType("hud", "chipMenu")
-class ChipMenuHud extends Hud {
+class ChipMenuHud extends Hud implements IMenuAxes {
 
 	@:arpBarrier @:arpField public var chip:Chip;
 	@:arpField public var dPosition:ArpPosition;
@@ -18,23 +18,7 @@ class ChipMenuHud extends Hud {
 
 	@:arpImpl private var arpImpl:ChipMenuHudImpl;
 
-	public function new() {
-		super();
-	}
+	public function new() super();
 
-	override public function interact(input:Input):Bool {
-		var axis:InputAxis = input.axis(this.axis);
-		if (axis.isTrigger) {
-			if (axis.value > 0) {
-				this.menu.shift(1);
-			} else if (axis.value < 0) {
-				this.menu.shift(-1);
-			}
-		}
-		var execute:InputAxis = input.axis(this.execute);
-		if (execute.isTriggerDown) {
-			this.menu.executeSelection();
-		}
-		return true;
-	}
+	override public function interact(input:Input):Bool return menu.interactWith(input, this);
 }

--- a/src/arpx/input/Input.hx
+++ b/src/arpx/input/Input.hx
@@ -20,7 +20,10 @@ class Input implements IArpObject implements ITickable implements IInputImpl {
 		this.states = new StdMap<InputSource, Float>();
 	}
 
-	public function getState(source:InputSource):Float return this.states.get(source);
+	public function getState(source:InputSource):Float {
+		var result = this.states.get(source);
+		return if (result != null) result else 0.0;
+	}
 	public function setState(source:InputSource, value:Float = 1.0):Void this.states.set(source, value);
 	public function unsetState(source:InputSource, value:Float = 0.0):Void this.states.set(source, value);
 	public function clearStates():Void this.states.clear();

--- a/src/arpx/inputAxis/InputAxis.hx
+++ b/src/arpx/inputAxis/InputAxis.hx
@@ -14,24 +14,24 @@ class InputAxis implements ITickableChild<Input> implements IArpObject {
 	private var bindings:ArrayList<InputAxisBinding>;
 	private var nextValue:Float = 0;
 
-	private var state(default, null):Bool = false;
+	private var state(default, null):Int = 0;
 	private var stateDuration(default, null):Float = 0;
 	private var threshold(default, default):Float = 0.6;
 
 	public var isUp(get, null):Bool;
-	inline private function get_isUp():Bool return !this.state;
+	inline private function get_isUp():Bool return this.state == 0;
 
 	public var isDown(get, null):Bool;
-	inline private function get_isDown():Bool return this.state;
+	inline private function get_isDown():Bool return this.state != 0;
 
 	public var isTrigger(get, null):Bool;
 	inline private function get_isTrigger():Bool return this.stateDuration == 0;
 
 	public var isTriggerUp(get, null):Bool;
-	inline private function get_isTriggerUp():Bool return this.isTrigger && !this.state;
+	inline private function get_isTriggerUp():Bool return this.isTrigger && this.isUp;
 
 	public var isTriggerDown(get, null):Bool;
-	inline private function get_isTriggerDown():Bool return this.isTrigger && this.state;
+	inline private function get_isTriggerDown():Bool return this.isTrigger && this.isDown;
 
 	public function new() {
 		bindings = new ArrayList<InputAxisBinding>();
@@ -47,7 +47,7 @@ class InputAxis implements ITickableChild<Input> implements IArpObject {
 			this.nextValue += value * binding.factor;
 		}
 
-		var newState:Bool = this.nextValue >= threshold || this.nextValue <= -threshold;
+		var newState:Int = if (this.nextValue >= threshold) 1 else if (this.nextValue <= -threshold) -1 else 0;
 		if (this.state != newState) {
 			this.stateDuration = 0;
 			this.state = newState;

--- a/src/arpx/menu/IMenuAxes.hx
+++ b/src/arpx/menu/IMenuAxes.hx
@@ -1,0 +1,6 @@
+package arpx.menu;
+
+interface IMenuAxes {
+	var axis:String;
+	var execute:String;
+}

--- a/src/arpx/menu/IMenuAxes.hx
+++ b/src/arpx/menu/IMenuAxes.hx
@@ -1,7 +1,7 @@
 package arpx.menu;
 
 interface IMenuAxes {
-	var axis:String;
-	var execute:String;
-	var abort:String;
+	var axis(get, set):String;
+	var execute(get, set):String;
+	var abort(get, set):String;
 }

--- a/src/arpx/menu/IMenuAxes.hx
+++ b/src/arpx/menu/IMenuAxes.hx
@@ -3,4 +3,5 @@ package arpx.menu;
 interface IMenuAxes {
 	var axis:String;
 	var execute:String;
+	var abort:String;
 }

--- a/src/arpx/menu/Menu.hx
+++ b/src/arpx/menu/Menu.hx
@@ -2,6 +2,8 @@ package arpx.menu;
 
 import arp.domain.IArpObject;
 import arp.ds.IOmap;
+import arpx.input.Input;
+import arpx.inputAxis.InputAxis;
 import arpx.menuItem.MenuItem;
 
 @:arpType("menu")
@@ -39,6 +41,22 @@ class Menu implements IArpObject {
 
 	inline public function executeSelection():Bool {
 		return execute(this.value);
+	}
+
+	public function interactWith(input:Input, axes:IMenuAxes):Bool {
+		var axis:InputAxis = input.axis(axes.axis);
+		if (axis.isTrigger) {
+			if (axis.value > 0) {
+				this.shift(1);
+			} else if (axis.value < 0) {
+				this.shift(-1);
+			}
+		}
+		var execute:InputAxis = input.axis(axes.execute);
+		if (execute.isTriggerDown) {
+			this.executeSelection();
+		}
+		return true;
 	}
 }
 

--- a/src/arpx/menu/Menu.hx
+++ b/src/arpx/menu/Menu.hx
@@ -5,11 +5,14 @@ import arp.ds.IOmap;
 import arpx.input.Input;
 import arpx.inputAxis.InputAxis;
 import arpx.menuItem.MenuItem;
+import arpx.proc.Proc;
 
 @:arpType("menu")
 class Menu implements IArpObject {
 	@:arpField public var visible:Bool = true;
 	@:arpField(true) public var menuItems:IOmap<String, MenuItem>;
+
+	@:arpField public var abort:Proc;
 
 	@:arpField public var value:Int;
 
@@ -43,6 +46,12 @@ class Menu implements IArpObject {
 		return execute(this.value);
 	}
 
+	inline public function executeAbort():Bool {
+		if (this.abort == null) return false;
+		this.abort.execute();
+		return true;
+	}
+
 	public function interactWith(input:Input, axes:IMenuAxes):Bool {
 		var axis:InputAxis = input.axis(axes.axis);
 		if (axis.isTrigger) {
@@ -55,6 +64,12 @@ class Menu implements IArpObject {
 		var execute:InputAxis = input.axis(axes.execute);
 		if (execute.isTriggerDown) {
 			this.executeSelection();
+		}
+		if (axes.abort != null) {
+			var abort:InputAxis = input.axis(axes.abort);
+			if (abort.isTriggerDown) {
+				this.executeAbort();
+			}
 		}
 		return true;
 	}

--- a/src/arpx/menu/Menu.hx
+++ b/src/arpx/menu/Menu.hx
@@ -61,14 +61,36 @@ class Menu implements IArpObject {
 				this.shift(-1);
 			}
 		}
+		for (kv in this.menuItems.amend()) {
+			var index:Int = kv.index;
+			var name:String = kv.key;
+			var menuItem:MenuItem = kv.value;
+			if (menuItem.shortcut != null) {
+				var shortcut:InputAxis = input.axis(menuItem.shortcut);
+				if (shortcut.isTriggerDown) {
+					if (this.value != index) {
+						this.value = index;
+						if (menuItem.shortcut == menuItem.hotkey) {
+							return true;
+						}
+					}
+				}
+			}
+			if (menuItem.hotkey != null) {
+				var hotkey:InputAxis = input.axis(menuItem.hotkey);
+				if (hotkey.isTriggerDown) {
+					return this.execute(index);
+				}
+			}
+		}
 		var execute:InputAxis = input.axis(axes.execute);
 		if (execute.isTriggerDown) {
-			this.executeSelection();
+			return this.executeSelection();
 		}
 		if (axes.abort != null) {
 			var abort:InputAxis = input.axis(axes.abort);
 			if (abort.isTriggerDown) {
-				this.executeAbort();
+				return this.executeAbort();
 			}
 		}
 		return true;

--- a/src/arpx/menu/Menu.hx
+++ b/src/arpx/menu/Menu.hx
@@ -27,7 +27,7 @@ class Menu implements IArpObject {
 
 	public function new() return;
 
-	public function shift(delta:Int):Int {
+	private function shift(delta:Int):Int {
 		var value:Int = this.value + delta;
 		if (value < 0) value = 0;
 		var length:Int = this.menuItems.length;
@@ -35,18 +35,18 @@ class Menu implements IArpObject {
 		return this.value = value;
 	}
 
-	public function execute(value:Int):Bool {
+	private function execute(value:Int):Bool {
 		var item:MenuItem = this.menuItems.getAt(value);
 		if (item == null || item.proc == null) return false;
 		item.proc.execute();
 		return true;
 	}
 
-	inline public function executeSelection():Bool {
+	private function executeSelection():Bool {
 		return execute(this.value);
 	}
 
-	inline public function executeAbort():Bool {
+	private function executeAbort():Bool {
 		if (this.abort == null) return false;
 		this.abort.execute();
 		return true;

--- a/src/arpx/menu/Menu.hx
+++ b/src/arpx/menu/Menu.hx
@@ -61,8 +61,8 @@ class Menu implements IArpObject {
 				this.shift(-1);
 			}
 		}
-		for (kv in this.menuItems.amend()) {
-			var index:Int = kv.index;
+		var index:Int = 0;
+		for (kv in this.menuItems.keyValueIterator()) {
 			var name:String = kv.key;
 			var menuItem:MenuItem = kv.value;
 			if (menuItem.shortcut != null) {
@@ -82,6 +82,7 @@ class Menu implements IArpObject {
 					return this.execute(index);
 				}
 			}
+			index++;
 		}
 		var execute:InputAxis = input.axis(axes.execute);
 		if (execute.isTriggerDown) {

--- a/src/arpx/menuItem/MenuItem.hx
+++ b/src/arpx/menuItem/MenuItem.hx
@@ -9,6 +9,9 @@ class MenuItem implements IArpObject {
 	@:arpField public var text:TextData;
 	@:arpField public var proc:Proc;
 
+	@:arpField public var hotkey:String;
+	@:arpField public var shortcut:String;
+
 	public function new() {
 	}
 }

--- a/src/arpx/proc/DynamicProc.hx
+++ b/src/arpx/proc/DynamicProc.hx
@@ -1,0 +1,11 @@
+package arpx.proc;
+
+@:arpType("proc", "dynamic")
+class DynamicProc extends Proc {
+
+	public function new() super();
+
+	override public function execute():Void onExecute();
+
+	dynamic public function onExecute():Void return;
+}

--- a/tests/arpx/ArpEngineTestSuite.hx
+++ b/tests/arpx/ArpEngineTestSuite.hx
@@ -7,6 +7,7 @@ import arpx.file.LocalFileCase;
 import arpx.impl.cross.structs.ArpTransformCase;
 import arpx.input.KeyInputCase;
 import arpx.macro.ArpStructsMacroArpObjectCase;
+import arpx.menu.MenuCase;
 import arpx.paramsOp.RewireParamsOpCase;
 import arpx.structs.ArpColorCase;
 import arpx.structs.ArpColorFlashCase;
@@ -57,6 +58,8 @@ class ArpEngineTestSuite {
 		r.load(LocalFileCase);
 
 		r.load(KeyInputCase);
+
+		r.load(MenuCase);
 
 		r.load(RewireParamsOpCase);
 

--- a/tests/arpx/menu/MenuCase.hx
+++ b/tests/arpx/menu/MenuCase.hx
@@ -1,0 +1,177 @@
+﻿package arpx.menu;
+
+import arpx.proc.DynamicProc;
+import picotest.PicoAssert;
+import arpx.input.InputSource;
+import arp.domain.ArpDomain;
+import arp.seed.ArpSeed;
+import arpx.input.LocalInput;
+import arpx.menu.Menu;
+import arpx.menuItem.MenuItem;
+import arpx.text.FixedTextData;
+
+import picotest.PicoAssert.*;
+
+class MenuCase {
+
+	private var domain:ArpDomain;
+	private var me:Menu;
+	private var input:LocalInput;
+
+	private var _tmp:Int = -1;
+	private var tmp(get, set):Int;
+	private function get_tmp():Int {
+		var value = _tmp;
+		_tmp = -1;
+		return value;
+	}
+	private function set_tmp(value:Int):Int return _tmp = value;
+
+	public function setup() {
+		var xml:Xml = Xml.parse('<data>
+			<menu name="menu">
+				<menuItem>
+					<text value="item0" />
+				</menuItem>
+				<menuItem>
+					<text value="item1" />
+				</menuItem>
+				<menuItem>
+					<text value="item2" />
+				</menuItem>
+				<menuItem>
+					<text value="item3" />
+				</menuItem>
+				<menuItem>
+					<text value="item4" />
+				</menuItem>
+				<menuItem shortcut="5" hotkey="7">
+					<text value="item5" />
+				</menuItem>
+				<menuItem shortcut="6" hotkey="6">
+					<text value="item6" />
+				</menuItem>
+				<menuItem>
+					<text value="item7" />
+				</menuItem>
+			</menu>
+			<input name="input" />
+		</data>').firstElement();
+		var seed:ArpSeed = ArpSeed.fromXml(xml);
+		domain = new ArpDomain();
+		domain.addTemplate(Menu, true);
+		domain.addTemplate(MenuItem, true);
+		domain.addTemplate(FixedTextData, true);
+		domain.addTemplate(LocalInput, true);
+		domain.loadSeed(seed);
+		me = domain.obj("menu", Menu);
+		input = domain.obj("input", LocalInput);
+		input.bindKeyAxis(1, "axis", 1);
+		input.bindKeyAxis(2, "axis", -1);
+		input.bindKeyAxis(3, "execute", 1);
+		input.bindKeyAxis(4, "abort", 1);
+		input.bindKeyAxis(5, "5", 1);
+		input.bindKeyAxis(6, "6", 1);
+		input.bindKeyAxis(7, "7", 1);
+
+		for (i in 0...me.menuItems.length) {
+			var proc:DynamicProc = domain.allocObject(DynamicProc);
+			var f:()->(()->Void) = () -> { () -> { tmp = i; }};
+			proc.onExecute = f();
+			me.menuItems.getAt(i).proc = proc;
+		}
+	}
+
+	public function testItem():Void {
+		PicoAssert.assertEquals("item0", me.selection.text.publish(null));
+		me.value = 3;
+		PicoAssert.assertEquals("item3", me.selection.text.publish(null));
+	}
+
+	public function testInteractWith():Void {
+		PicoAssert.assertEquals(0, me.value);
+		PicoAssert.assertEquals(-1, tmp);
+
+		me.interactWith(input, new MockAxes());
+		PicoAssert.assertEquals(0, me.value);
+		PicoAssert.assertEquals(-1, tmp);
+
+		input.setState(InputSource.Key(1));
+		input.tick(1.0);
+		assertEquals(1.0, input.axis("axis").value);
+		me.interactWith(input, new MockAxes());
+		PicoAssert.assertEquals(1, me.value);
+		PicoAssert.assertEquals(-1, tmp);
+
+		input.clearStates();
+		input.tick(1.0);
+
+		input.setState(InputSource.Key(2));
+		input.tick(1.0);
+		me.interactWith(input, new MockAxes());
+		PicoAssert.assertEquals(0, me.value);
+		PicoAssert.assertEquals(-1, tmp);
+
+		input.clearStates();
+		input.tick(1.0);
+
+		input.setState(InputSource.Key(3));
+		input.tick(1.0);
+		me.interactWith(input, new MockAxes());
+		PicoAssert.assertEquals(0, me.value);
+		PicoAssert.assertEquals(0, tmp);
+
+		input.clearStates();
+		input.tick(1.0);
+
+		input.setState(InputSource.Key(5));
+		input.tick(1.0);
+		me.interactWith(input, new MockAxes());
+		PicoAssert.assertEquals(5, me.value);
+		PicoAssert.assertEquals(-1, tmp);
+
+		input.clearStates();
+		input.tick(1.0);
+
+		input.setState(InputSource.Key(6));
+		input.tick(1.0);
+		me.interactWith(input, new MockAxes());
+		PicoAssert.assertEquals(6, me.value);
+		PicoAssert.assertEquals(-1, tmp);
+
+		input.clearStates();
+		input.tick(1.0);
+
+		input.setState(InputSource.Key(6));
+		input.tick(1.0);
+		me.interactWith(input, new MockAxes());
+		PicoAssert.assertEquals(6, me.value);
+		PicoAssert.assertEquals(6, tmp);
+
+		input.clearStates();
+		input.tick(1.0);
+
+		input.setState(InputSource.Key(7));
+		input.tick(1.0);
+		me.interactWith(input, new MockAxes());
+		PicoAssert.assertEquals(6, me.value);
+		PicoAssert.assertEquals(5, tmp);
+	}
+}
+
+private class MockAxes implements IMenuAxes {
+	public var axis(get, set):String;
+	public var execute(get, set):String;
+	public var abort(get, set):String;
+
+	public function new() return;
+
+	function get_axis():String return "axis";
+	function set_axis(value:String):String return "axis";
+
+	function get_execute():String return "execute";
+	function set_execute(value:String):String return "execute";
+
+	function get_abort():String return "abort";
+	function set_abort(value:String):String return "abort";
+}


### PR DESCRIPTION
Fixes #61 

- Abort button and proc (useful for cancel)
- Hotkey: direct execute item 
- Shortcut: direct select item

Might be very slow if thousands of entries in a menu, but having hotkeys and shortcuts outside `MenuItem`s seemed far more worse