### PR TITLE
ParametrizedTextData takes slash characters into account

### DIFF
--- a/src/arpx/chip/utils/StringChipUtil.hx
+++ b/src/arpx/chip/utils/StringChipUtil.hx
@@ -1,0 +1,19 @@
+package arpx.chip.utils;
+
+class StringChipUtil {
+
+	public static function lengthForStringChip(str:String):Int {
+		var b:Bool = false;
+		var outer:Int = 0;
+		var inner:Int = 0;
+		for (i in 0...str.length) {
+			switch (str.charCodeAt(i)) {
+				case "/".code:
+					if (b = !b) inner = 1; else { outer++; inner = 0; }
+				case _:
+					if (b) inner++ else outer++;
+			}
+		}
+		return outer+ inner;
+	}
+}

--- a/src/arpx/text/ParametrizedTextData.hx
+++ b/src/arpx/text/ParametrizedTextData.hx
@@ -2,6 +2,7 @@ package arpx.text;
 
 import arp.utils.FormatOption;
 import arp.utils.FormatText;
+import arpx.chip.utils.StringChipUtil;
 import arpx.structs.ArpParams;
 
 @:arpType("text", "ptext")
@@ -28,10 +29,18 @@ class ParametrizedTextData extends TextData {
 	private function _customAlign(str:String, formatOption:FormatOption):String return customAlign(str, formatOption);
 
 	dynamic public static function customFormatter(param:Any, formatOption:FormatOption):String {
-		return if (Std.is(param, TextData)) (param:TextData).publish() else null;
+		return defaultCustomFormatter(param, formatOption);
 	}
 
 	dynamic public static function customAlign(str:String, formatOption:FormatOption):String {
-		return null;
+		return defaultCustomAlign(str, formatOption);
+	}
+
+	inline public static function defaultCustomFormatter(param:Any, formatOption:FormatOption):String {
+		return if (Std.is(param, TextData)) (param:TextData).publish() else Std.string(param);
+	}
+
+	inline public static function defaultCustomAlign(str:String, formatOption:FormatOption):String {
+		return formatOption.basicPad(str, " ", (formatOption.width - StringChipUtil.lengthForStringChip(str)));
 	}
 }

--- a/tests/arpx/ArpEngineTestSuite.hx
+++ b/tests/arpx/ArpEngineTestSuite.hx
@@ -2,6 +2,7 @@ package arpx;
 
 import arp.testParams.PersistIoProviders.*;
 import arpx.automaton.AutomatonCase;
+import arpx.chip.utils.StringChipUtilCase;
 import arpx.driver.LinearDriverCase;
 import arpx.file.LocalFileCase;
 import arpx.impl.cross.structs.ArpTransformCase;
@@ -39,19 +40,19 @@ class ArpEngineTestSuite {
 
 		r.load(ArpStructsMacroArpObjectCase);
 
-		#if !arp_display_backend_stub
-		r.load(ArpTransformCase, persistIoProvider());
-		#end
-
 		#if arp_display_backend_flash
+		r.load(ArpTransformCase, persistIoProvider());
 		r.load(ArpTransformFlashCase);
 		#elseif arp_display_backend_heaps
+		r.load(ArpTransformCase, persistIoProvider());
 		r.load(ArpTransformHeapsCase);
 		#end
 
 		r.load(ArpEngineComponentsCase);
 
 		r.load(AutomatonCase);
+
+		r.load(StringChipUtilCase);
 
 		r.load(LinearDriverCase);
 

--- a/tests/arpx/chip/utils/StringChipUtilCase.hx
+++ b/tests/arpx/chip/utils/StringChipUtilCase.hx
@@ -1,0 +1,30 @@
+﻿package arpx.chip.utils;
+
+import arpx.chip.stringChip.StringChipStringIterator;
+import picotest.PicoAssert.*;
+
+class StringChipUtilCase {
+
+	private function len(str:String):Int return StringChipUtil.lengthForStringChip(str);
+	private function lenIter(str:String):Int return [for (x in new StringChipStringIterator(str)) x].length;
+
+	public function testLengthForStringChip() {
+		assertEquals(0, len(""));
+		assertEquals(4, len("1234"));
+		assertEquals(1, len("/space/"));
+		assertEquals(2, len("////"));
+		assertEquals(9, len("123/444/567/888/9"));
+		assertEquals(5, len("12/45"));
+		assertEquals(9, len("12/333/45/789"));
+	}
+
+	public function testStringChipStringIterator() {
+		assertEquals(lenIter(""), len(""));
+		assertEquals(lenIter("1234"), len("1234"));
+		assertEquals(lenIter("/space/"), len("/space/"));
+		assertEquals(lenIter("////"), len("////"));
+		assertEquals(lenIter("123/444/567/888/9"), len("123/444/567/888/9"));
+		assertEquals(lenIter("12/45"), len("12/45"));
+		assertEquals(lenIter("12/333/45/678"), len("12/333/45/678"));
+	}
+}

--- a/tests/arpx/text/ParametrizedTextDataCase.hx
+++ b/tests/arpx/text/ParametrizedTextDataCase.hx
@@ -14,7 +14,7 @@ class ParametrizedTextDataCase {
 
 	public function setup() {
 		var xml:Xml = Xml.parse('<data>
-		<text class="ptext" name="name1" value="{foo}{bar}" />
+		<text class="ptext" name="name1" value="{foo}{bar:3r}" />
 		</data>
 		').firstElement();
 		var seed:ArpSeed = ArpSeed.fromXml(xml);
@@ -26,11 +26,11 @@ class ParametrizedTextDataCase {
 	}
 
 	public function testFields() {
-		assertEquals("{foo}{bar}", me.value);
+		assertEquals("{foo}{bar:3r}", me.value);
 	}
 
 	public function testPublish() {
-		assertEquals("{foo}{bar}", me.publish(null));
+		assertEquals("{foo}{bar:3r}", me.publish(null));
 	}
 
 	public function testComplexPublish() {
@@ -38,6 +38,10 @@ class ParametrizedTextDataCase {
 		params.set("foo", "hoge");
 		params.set("bar", "fuga");
 		assertEquals("hogefuga", me.publish(params));
+		var params:ArpParams = new ArpParams();
+		params.set("foo", "/hoge/");
+		params.set("bar", "/fuga/");
+		assertEquals("/hoge/  /fuga/", me.publish(params));
 	}
 
 }


### PR DESCRIPTION
`[{n:3r}]` % `/a/` = `[  /a/]`

Close #98