### PR TITLE
More versatile TextData.publish()

### DIFF
--- a/src/arpx/text/ArpFormatParams.hx
+++ b/src/arpx/text/ArpFormatParams.hx
@@ -1,0 +1,27 @@
+package arpx.text;
+
+import arp.utils.FormatText;
+import arpx.structs.ArpParams;
+
+abstract ArpFormatParams(TFormatParams) to TFormatParams {
+
+	inline private static function identity():ArpFormatParams {
+		return (name:String) -> name;
+	}
+
+	@:from inline public static function fromArpParams(params:ArpParams = null):ArpFormatParams {
+		return if (params == null) identity() else (name:String) -> params.get(name);
+	}
+
+	@:from inline public static function fromFunc(func:(name:String)->Any = null):ArpFormatParams {
+		return if (func == null) identity() else cast func;
+	}
+
+	@:from inline public static function fromArray<T>(array:Array<T> = null):ArpFormatParams {
+		return if (array == null) identity() else (name:String) -> array[Std.parseInt(name)];
+	}
+
+	inline public static function fromAnon(anon:Dynamic = null):ArpFormatParams {
+		return if (anon == null) identity() else (name:String) -> Reflect.field(anon, name);
+	}
+}

--- a/src/arpx/text/FixedTextData.hx
+++ b/src/arpx/text/FixedTextData.hx
@@ -1,7 +1,6 @@
 package arpx.text;
 
 import arp.domain.ArpDomain;
-import arpx.structs.ArpParams;
 
 @:arpType("text")
 class FixedTextData extends TextData {
@@ -12,7 +11,11 @@ class FixedTextData extends TextData {
 		super();
 	}
 
-	override public function publish(params:ArpParams = null):String {
+	override public function publish(params:ArpFormatParams = null):String {
+		return this.value;
+	}
+
+	override public function publishAnon(anon:Dynamic = null):String {
 		return this.value;
 	}
 

--- a/src/arpx/text/ParametrizedTextData.hx
+++ b/src/arpx/text/ParametrizedTextData.hx
@@ -3,7 +3,6 @@ package arpx.text;
 import arp.utils.FormatOption;
 import arp.utils.FormatText;
 import arpx.chip.utils.StringChipUtil;
-import arpx.structs.ArpParams;
 
 @:arpType("text", "ptext")
 class ParametrizedTextData extends TextData {
@@ -21,8 +20,12 @@ class ParametrizedTextData extends TextData {
 
 	public function new() super();
 
-	override public function publish(params:ArpParams = null):String {
-		return if (params == null) this.value else this.impl.publish((name:String) -> params.get(name));
+	override public function publish(params:ArpFormatParams = null):String {
+		return if (params == null) this.value else this.impl.publish(params);
+	}
+
+	override public function publishAnon(anon:Dynamic = null):String {
+		return if (anon == null) this.value else this.impl.publish(ArpFormatParams.fromAnon(anon));
 	}
 
 	private function _customFormatter(param:Any, formatOption:FormatOption):String return customFormatter(param, formatOption);

--- a/src/arpx/text/ResourceTextData.hx
+++ b/src/arpx/text/ResourceTextData.hx
@@ -1,7 +1,6 @@
 package arpx.text;
 
 import haxe.Resource;
-import arpx.structs.ArpParams;
 
 @:arpType("text", "resource")
 class ResourceTextData extends TextData {
@@ -12,7 +11,11 @@ class ResourceTextData extends TextData {
 		super();
 	}
 
-	override public function publish(params:ArpParams = null):String {
+	override public function publish(params:ArpFormatParams = null):String {
+		return Resource.getString(this.src);
+	}
+
+	override public function publishAnon(anon:Dynamic = null):String {
 		return Resource.getString(this.src);
 	}
 }

--- a/src/arpx/text/TextData.hx
+++ b/src/arpx/text/TextData.hx
@@ -1,7 +1,6 @@
 package arpx.text;
 
 import arp.domain.IArpObject;
-import arpx.structs.ArpParams;
 import arpx.text.FixedTextData;
 
 @:arpType("text", "null")
@@ -9,9 +8,14 @@ class TextData implements IArpObject {
 
 	public function new() return;
 
-	public function publish(params:ArpParams = null):String return "";
+	public function publish(params:ArpFormatParams = null):String return "";
+	public function publishAnon(params:Dynamic = null):String return "";
 
-	public function publishTextData(params:ArpParams = null):TextData {
+	public function publishTextData(params:ArpFormatParams = null):TextData {
 		return FixedTextData.allocObject(this.arpDomain, this.publish(params));
+	}
+
+	public function publishTextDataAnon(anon:Dynamic = null):TextData {
+		return FixedTextData.allocObject(this.arpDomain, this.publish(ArpFormatParams.fromAnon(anon)));
 	}
 }

--- a/tests/arpx/text/ParametrizedTextDataCase.hx
+++ b/tests/arpx/text/ParametrizedTextDataCase.hx
@@ -29,8 +29,13 @@ class ParametrizedTextDataCase {
 		assertEquals("{foo}{bar:3r}", me.value);
 	}
 
-	public function testPublish() {
+	public function testPublishNull() {
 		assertEquals("{foo}{bar:3r}", me.publish(null));
+	}
+
+	public function testPublishAnon() {
+		assertEquals("hogefuga", me.publishAnon({foo: "hoge", bar: "fuga"}));
+		assertEquals("/hoge/  /fuga/", me.publishAnon({foo: "/hoge/", bar: "/fuga/"}));
 	}
 
 	public function testComplexPublish() {

--- a/tests/arpx/text/TextDataCase.hx
+++ b/tests/arpx/text/TextDataCase.hx
@@ -29,8 +29,12 @@ class TextDataCase {
 		assertEquals("{foo}{bar}", me.value);
 	}
 
-	public function testPublish() {
+	public function testPublishNull() {
 		assertEquals("{foo}{bar}", me.publish(null));
+	}
+
+	public function testPublishAnon() {
+		assertEquals("{foo}{bar}", me.publishAnon({foo: "hoge", bar: "fuga"}));
 	}
 
 	public function testComplexPublish() {


### PR DESCRIPTION
Technically breaking, but we want anything to be less dependent to ArpParams