### PR TITLE
Store ArpColor instance in ArpParams

### DIFF
--- a/src/arpx/impl/cross/chip/decorators/ColorizeParamChipImpl.hx
+++ b/src/arpx/impl/cross/chip/decorators/ColorizeParamChipImpl.hx
@@ -26,11 +26,9 @@ class ColorizeParamChipImpl extends ArpObjectImplBase implements IChipImpl {
 		}
 	}
 
-	private var _workColor:ArpColor = new ArpColor();
+	private var _white:ArpColor = ArpColor.WHITE;
 	inline private function color(params:IArpParamsRead, key:String):ArpColor {
-		var color:ArpColor = _workColor;
-		color.value32 = params.getIntOrDefault(key, 0xffffffff);
-		return color;
+		return params.getArpColorOrDefault(key, _white);
 	}
 }
 

--- a/src/arpx/impl/cross/chip/decorators/TintParamChipImpl.hx
+++ b/src/arpx/impl/cross/chip/decorators/TintParamChipImpl.hx
@@ -6,7 +6,6 @@ import arpx.impl.ArpObjectImplBase;
 import arpx.impl.cross.chip.IChipImpl;
 import arpx.impl.cross.display.RenderContext;
 import arpx.structs.ArpColor;
-import arpx.structs.ArpParams;
 import arpx.structs.IArpParamsRead;
 
 class TintParamChipImpl extends ArpObjectImplBase implements IChipImpl {
@@ -19,16 +18,14 @@ class TintParamChipImpl extends ArpObjectImplBase implements IChipImpl {
 	}
 
 	public function render(context:RenderContext, params:IArpParamsRead = null):Void {
-		context.tints.dup().applyMul(tint(params));
+		context.tints.dup().applyMul(color(params, chip.paramsKey));
 		this.chip.chip.render(context, params);
 		context.tints.pop();
 	}
 
-	private var _workColor:ArpColor = new ArpColor();
-	inline private function tint(params:IArpParamsRead):ArpColor {
-		var color:ArpColor = _workColor;
-		color.value32 = params.getIntOrDefault(chip.paramsKey, 0xffffffff);
-		return color;
+	private var _white:ArpColor = ArpColor.WHITE;
+	inline private function color(params:IArpParamsRead, key:String):ArpColor {
+		return params.getArpColorOrDefault(key, _white);
 	}
 }
 

--- a/src/arpx/paramsOp/filters/ArpParamsFilter.hx
+++ b/src/arpx/paramsOp/filters/ArpParamsFilter.hx
@@ -1,5 +1,6 @@
 package arpx.paramsOp.filters;
 
+import arpx.structs.ArpColor;
 import arpx.structs.ArpDirection;
 import arpx.structs.ArpParamsKey;
 import arpx.structs.IArpParamsRead;
@@ -15,12 +16,14 @@ class ArpParamsFilter implements IArpParamsRead {
 	public function getString(key:ArpParamsKey, defaultValue:String = null):Null<String> return ArpParamsMacros.getSafe(key, defaultValue, String);
 	public function getBool(key:ArpParamsKey, defaultValue:Bool = null):Null<Bool> return ArpParamsMacros.getSafe(key, defaultValue, Bool);
 	public function getArpDirection(key:ArpParamsKey, defaultValue:ArpDirection = null):Null<ArpDirection> return ArpParamsMacros.getSafe(key, defaultValue, ArpDirection);
+	public function getArpColor(key:ArpParamsKey, defaultValue:ArpColor = null):Null<ArpColor> return ArpParamsMacros.getSafe(key, defaultValue, getArpColor);
 
 	public function getIntOrDefault(key:ArpParamsKey, defaultValue:Int = 0):Int return ArpParamsMacros.getSafe(key, defaultValue, Int);
 	public function getFloatOrDefault(key:ArpParamsKey, defaultValue:Float = 0):Float return ArpParamsMacros.getSafe(key, defaultValue, Float);
 	public function getStringOrDefault(key:ArpParamsKey, defaultValue:String = ""):String return ArpParamsMacros.getSafe(key, defaultValue, String);
 	public function getBoolOrDefault(key:ArpParamsKey, defaultValue:Bool = false):Bool return ArpParamsMacros.getSafe(key, defaultValue, Bool);
 	public function getArpDirectionOrDefault(key:ArpParamsKey, defaultValue:ArpDirection):ArpDirection return ArpParamsMacros.getSafe(key, defaultValue, ArpDirection);
+	public function getArpColorOrDefault(key:ArpParamsKey, defaultValue:ArpColor):ArpColor return ArpParamsMacros.getSafe(key, defaultValue, getArpColor);
 
 	public function getAsString(key:ArpParamsKey, defaultValue:String = null):String return ArpParamsMacros.getAsString(key, defaultValue);
 

--- a/src/arpx/structs/ArpColor.hx
+++ b/src/arpx/structs/ArpColor.hx
@@ -137,6 +137,10 @@ class ArpColor implements IArpStruct {
 		return "[ArpColor #" + Std.string(this.value32) + " ]";
 	}
 
+	inline public static function isColorLikeString(value:String):Bool {
+		return value.indexOf("#") == 0;
+	}
+
 	#if (flash || openfl)
 
 	public function toMultiplier():ColorTransform {

--- a/src/arpx/structs/ArpParams.hx
+++ b/src/arpx/structs/ArpParams.hx
@@ -52,7 +52,7 @@ class ArpParams extends ReadOnlyArpParams implements IArpStruct implements IArpP
 				default:
 					if (ArpStringUtil.isNumeric(value)) {
 						this.set(key, ArpStringUtil.parseFloatDefault(value));
-					} else if (ArpStringUtil.isColorish(value)) {
+					} else if (ArpColor.isColorLikeString(value)) {
 						this.set(key, new ArpColor().initWithString(value));
 					} else {
 						this.set(key, value);

--- a/src/arpx/structs/ArpParams.hx
+++ b/src/arpx/structs/ArpParams.hx
@@ -43,9 +43,17 @@ class ArpParams extends ReadOnlyArpParams implements IArpStruct implements IArpP
 					this.set(key, new ArpDirection().initWithString(value));
 				case "idir":
 					this.set(key, new ArpDirection(ArpStringUtil.parseHex(value)));
+				case "color":
+					this.set(key, new ArpColor().initWithString(value).value32);
+				case "string":
+					this.set(key, value);
+				case "number":
+					this.set(key, ArpStringUtil.parseFloatDefault(value));
 				default:
 					if (ArpStringUtil.isNumeric(value)) {
 						this.set(key, ArpStringUtil.parseFloatDefault(value));
+					} else if (ArpStringUtil.isColorish(value)) {
+						this.set(key, new ArpColor().initWithString(value).value32);
 					} else {
 						this.set(key, value);
 					}

--- a/src/arpx/structs/ArpParams.hx
+++ b/src/arpx/structs/ArpParams.hx
@@ -44,7 +44,7 @@ class ArpParams extends ReadOnlyArpParams implements IArpStruct implements IArpP
 				case "idir":
 					this.set(key, new ArpDirection(ArpStringUtil.parseHex(value)));
 				case "color":
-					this.set(key, new ArpColor().initWithString(value).value32);
+					this.set(key, new ArpColor().initWithString(value));
 				case "string":
 					this.set(key, value);
 				case "number":
@@ -53,7 +53,7 @@ class ArpParams extends ReadOnlyArpParams implements IArpStruct implements IArpP
 					if (ArpStringUtil.isNumeric(value)) {
 						this.set(key, ArpStringUtil.parseFloatDefault(value));
 					} else if (ArpStringUtil.isColorish(value)) {
-						this.set(key, new ArpColor().initWithString(value).value32);
+						this.set(key, new ArpColor().initWithString(value));
 					} else {
 						this.set(key, value);
 					}

--- a/src/arpx/structs/IArpParamsRead.hx
+++ b/src/arpx/structs/IArpParamsRead.hx
@@ -8,12 +8,14 @@ interface IArpParamsRead {
 	function getString(key:ArpParamsKey, defaultValue:String = null):Null<String>;
 	function getBool(key:ArpParamsKey, defaultValue:Bool = null):Null<Bool>;
 	function getArpDirection(key:ArpParamsKey, defaultValue:ArpDirection = null):Null<ArpDirection>;
+	function getArpColor(key:ArpParamsKey, defaultValue:ArpColor = null):Null<ArpColor>;
 
 	function getIntOrDefault(key:ArpParamsKey, defaultValue:Int = 0):Int;
 	function getFloatOrDefault(key:ArpParamsKey, defaultValue:Float = 0.0):Float;
 	function getStringOrDefault(key:ArpParamsKey, defaultValue:String = ""):String;
 	function getBoolOrDefault(key:ArpParamsKey, defaultValue:Bool = false):Bool;
 	function getArpDirectionOrDefault(key:ArpParamsKey, defaultValue:ArpDirection):ArpDirection;
+	function getArpColorOrDefault(key:ArpParamsKey, defaultValue:ArpColor):ArpColor;
 
 	function getAsString(key:ArpParamsKey, defaultValue:String = null):String;
 

--- a/src/arpx/structs/params/ArpParamsValue.hx
+++ b/src/arpx/structs/params/ArpParamsValue.hx
@@ -9,12 +9,14 @@ abstract ArpParamsValue(Any) from Any to Any {
 	@:from inline public static function fromString(value:String):ArpParamsValue return new ArpParamsValue(value);
 	@:from inline public static function fromBool(value:Bool):ArpParamsValue return new ArpParamsValue(value);
 	@:from inline public static function fromArpDirection(value:ArpDirection):ArpParamsValue return new ArpParamsValue(value);
+	@:from inline public static function fromArpColor(value:ArpColor):ArpParamsValue return new ArpParamsValue(value);
 
 	@:to inline public function toInt():Int return this;
 	@:to inline public function toFloat():Float return this;
 	@:to inline public function toString():String return this;
 	@:to inline public function toBool():Bool return this;
 	@:to inline public function toArpDirection():ArpDirection return this;
+	@:to inline public function toArpColor():ArpColor return this;
 
 	public var value(get, set):Int;
 	inline private function get_value():UInt return toArpDirection().value;

--- a/src/arpx/structs/params/EmptyArpParams.hx
+++ b/src/arpx/structs/params/EmptyArpParams.hx
@@ -14,12 +14,14 @@ class EmptyArpParams implements IArpParamsRead {
 	public function getString(key:ArpParamsKey, defaultValue = null):Null<String> return defaultValue;
 	public function getBool(key:ArpParamsKey, defaultValue = null):Null<Bool> return defaultValue;
 	public function getArpDirection(key:ArpParamsKey, defaultValue = null):Null<ArpDirection> return defaultValue;
+	public function getArpColor(key:ArpParamsKey, defaultValue = null):Null<ArpColor> return defaultValue;
 
 	public function getIntOrDefault(key:ArpParamsKey, defaultValue = 0):Int return defaultValue;
 	public function getFloatOrDefault(key:ArpParamsKey, defaultValue = 0.0):Float return defaultValue;
 	public function getStringOrDefault(key:ArpParamsKey, defaultValue = ""):String return defaultValue;
 	public function getBoolOrDefault(key:ArpParamsKey, defaultValue = false):Bool return defaultValue;
 	public function getArpDirectionOrDefault(key:ArpParamsKey, defaultValue):ArpDirection return ArpDirection.EAST;
+	public function getArpColorOrDefault(key:ArpParamsKey, defaultValue):ArpColor return ArpColor.WHITE;
 
 	public function getAsString(key:ArpParamsKey, defaultValue = null):String return defaultValue;
 

--- a/src/arpx/structs/params/ReadOnlyArpParams.hx
+++ b/src/arpx/structs/params/ReadOnlyArpParams.hx
@@ -17,12 +17,14 @@ class ReadOnlyArpParams implements IArpParamsRead {
 	public function getString(key:ArpParamsKey, defaultValue = null):Null<String> return ArpParamsMacros.getSafe(key, defaultValue, String);
 	public function getBool(key:ArpParamsKey, defaultValue = null):Null<Bool> return ArpParamsMacros.getSafe(key, defaultValue, Bool);
 	public function getArpDirection(key:ArpParamsKey, defaultValue = null):Null<ArpDirection> return ArpParamsMacros.getSafe(key, defaultValue, ArpDirection);
+	public function getArpColor(key:ArpParamsKey, defaultValue = null):Null<ArpColor> return ArpParamsMacros.getSafe(key, defaultValue, ArpColor);
 
 	public function getIntOrDefault(key:ArpParamsKey, defaultValue = 0):Int return ArpParamsMacros.getSafe(key, defaultValue, Int);
 	public function getFloatOrDefault(key:ArpParamsKey, defaultValue = 0.0):Float return ArpParamsMacros.getSafe(key, defaultValue, Float);
 	public function getStringOrDefault(key:ArpParamsKey, defaultValue = ""):String return ArpParamsMacros.getSafe(key, defaultValue, String);
 	public function getBoolOrDefault(key:ArpParamsKey, defaultValue = false):Bool return ArpParamsMacros.getSafe(key, defaultValue, Bool);
 	public function getArpDirectionOrDefault(key:ArpParamsKey, defaultValue):ArpDirection return ArpParamsMacros.getSafe(key, defaultValue, ArpDirection);
+	public function getArpColorOrDefault(key:ArpParamsKey, defaultValue):ArpColor return ArpParamsMacros.getSafe(key, defaultValue, ArpColor);
 
 	public function getAsString(key:ArpParamsKey, defaultValue = null):String return ArpParamsMacros.getAsString(key, defaultValue);
 
@@ -33,6 +35,11 @@ class ReadOnlyArpParams implements IArpParamsRead {
 			if (value == null) continue;
 			if (Std.is(value, ArpDirection)) {
 				value = StringTools.hex(cast(value, ArpDirection).value, 8) + ":idir";
+			} else if (Std.is(value, ArpColor)) {
+				var value32:Int = cast(value, ArpColor).value32;
+				var value24:Int = value32 & 0xffffff;
+				var alpha:Int = value32 >>> 24;
+				value = "#" + StringTools.hex(value24, 6) + "@" + StringTools.hex(alpha, 2) + ":color";
 			}
 			result.push(name.toString() + ":" + Std.string(value));
 		}

--- a/tests/arpx/structs/ArpParamsCase.hx
+++ b/tests/arpx/structs/ArpParamsCase.hx
@@ -23,10 +23,12 @@ class ArpParamsCase {
 		params["c"] = 10;
 		params["d"] = ArpDirection.LEFT;
 		params.set("e", "f");
+		params.set("g", ArpColor.RED);
 		assertEquals("b", params["a"]);
 		assertEquals(10, params["c"]);
 		assertEquals(ArpDirection.LEFT.value, params["d"].value);
 		assertEquals("f", params["e"]);
+		assertEquals(ArpColor.RED.value32, params["g"].toArpColor().value32);
 	}
 
 	public function testToString():Void {
@@ -38,14 +40,17 @@ class ArpParamsCase {
 		assertMatch(Matchers.containsInAnyOrder("a:b", "c:10"), Std.string(params).split(","));
 		params["d"] = ArpDirection.LEFT;
 		assertMatch(Matchers.containsInAnyOrder("a:b", "c:10", "d:80000000:idir"), Std.string(params).split(","));
+		params["e"] = ArpColor.RED;
+		assertMatch(Matchers.containsInAnyOrder("a:b", "c:10", "d:80000000:idir", "e:#FF0000@FF:color"), Std.string(params).split(","));
 	}
 
 	public function initWithSeedTest():Void {
 		var params:ArpParamsProxy = new ArpParams();
-		params.initWithSeed(ArpSeed.fromXmlString("<params>a:b,c:10,d:80000000:idir,faceValue</params>"));
+		params.initWithSeed(ArpSeed.fromXmlString("<params>a:b,c:10,d:80000000:idir,e:#ff0000@ff:color,faceValue</params>"));
 		assertEquals("b", params["a"]);
 		assertEquals(10, params["c"]);
 		assertEquals(ArpDirection.LEFT.value, params["d"].value);
+		assertEquals(ArpColor.RED.value32, params["e"].toArpColor().value32);
 		assertEquals("faceValue", params["face"]);
 	}
 
@@ -54,10 +59,12 @@ class ArpParamsCase {
 		params["a"] = "b";
 		params["c"] = 10;
 		params["d"] = ArpDirection.LEFT;
+		params["e"] = ArpColor.RED;
 		var params2:ArpParamsProxy = params.clone();
 		assertEquals(params["a"], params2["a"]);
 		assertEquals(params["c"], params2["c"]);
 		assertEquals(params["d"].value, params2["d"].value);
+		assertEquals(params["e"].toArpColor().value32, params2["e"].toArpColor().value32);
 	}
 
 	public function testCopyFrom():Void {
@@ -65,10 +72,12 @@ class ArpParamsCase {
 		params["a"] = "b";
 		params["c"] = 10;
 		params["d"] = ArpDirection.LEFT;
+		params["e"] = ArpColor.RED;
 		var params2:ArpParamsProxy = new ArpParams().copyFrom(params);
 		assertEquals(params["a"], params2["a"]);
 		assertEquals(params["c"], params2["c"]);
 		assertEquals(params["d"].value, params2["d"].value);
+		assertEquals(params["e"].toArpColor().value32, params2["e"].toArpColor().value32);
 	}
 
 	public function testPersist():Void {
@@ -76,19 +85,22 @@ class ArpParamsCase {
 		params["a"] = "b";
 		params["c"] = 10;
 		params["d"] = ArpDirection.LEFT;
+		params["e"] = ArpColor.RED;
 		var params2:ArpParamsProxy = new ArpParams();
 		params.writeSelf(provider.output);
 		params2.readSelf(provider.input);
 		assertEquals(params["a"], params2["a"]);
 		assertEquals(params["c"], params2["c"]);
 		assertEquals(params["d"].value, params2["d"].value);
+		assertEquals(params["e"].toArpColor().value32, params2["e"].toArpColor().value32);
 	}
 
 	public function testFromAnon():Void {
-		var params:ArpParamsProxy = ArpParams.fromAnon({a: "b", c: 10, d: ArpDirection.LEFT});
+		var params:ArpParamsProxy = ArpParams.fromAnon({a: "b", c: 10, d: ArpDirection.LEFT, e: ArpColor.RED});
 		assertEquals("b", params["a"]);
 		assertEquals(10, params["c"]);
 		assertEquals(ArpDirection.LEFT.value, params["d"].value);
+		assertEquals(ArpColor.RED.value32, params["e"].toArpColor().value32);
 	}
 
 	public function testGetSafe():Void {


### PR DESCRIPTION
This is breaking, and we have to break again if we want to turn ArpStructs into abstracts (which may be more performant), but a great improvement anyway...